### PR TITLE
Survive invalid app creation message

### DIFF
--- a/utility-evaluator/src/main/java/eu/nebulous/utilityevaluator/communication/exnconnector/DslGenericMessageHandler.java
+++ b/utility-evaluator/src/main/java/eu/nebulous/utilityevaluator/communication/exnconnector/DslGenericMessageHandler.java
@@ -10,6 +10,8 @@ import eu.nebulouscloud.exn.core.SyncedPublisher;
 import java.util.Map;
 
 import org.apache.qpid.protonj2.client.Message;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -42,12 +44,15 @@ public class DslGenericMessageHandler extends Handler {
         //Application appFromMessage = new Application(genericDSLMessage);
 
         JsonNode appMessage = mapper.valueToTree(body);
-        Application app = new Application(appMessage);    
+        Application app;
+	try {
+	    app = new Application(appMessage);
+	} catch (JsonProcessingException e) {
+            log.error("Could not read app creation message", e);
+            return;
+	}
         log.info("Application {}, with name {}, has variables: {}", app.getApplicationId(), app.getApplicationName(), app.getVariables().toString());
-                
-            
         app = controller.createInitialCostPerformanceIndicators(app);
-
     }
 
         

--- a/utility-evaluator/src/main/java/eu/nebulous/utilityevaluator/external/KubevelaAnalyzer.java
+++ b/utility-evaluator/src/main/java/eu/nebulous/utilityevaluator/external/KubevelaAnalyzer.java
@@ -1,6 +1,7 @@
 package eu.nebulous.utilityevaluator.external;
 
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -192,6 +193,9 @@ public class KubevelaAnalyzer {
      * @throws JsonProcessingException if kubevela does not contain valid YAML.
      */
     public static JsonNode parseKubevela(String kubevela) throws JsonProcessingException {
+        if (kubevela == null) {
+            throw new JsonParseException("The provided string value was null");
+        }
         return yamlMapper.readTree(kubevela);
     }
 

--- a/utility-evaluator/src/main/java/eu/nebulous/utilityevaluator/model/Application.java
+++ b/utility-evaluator/src/main/java/eu/nebulous/utilityevaluator/model/Application.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import eu.nebulous.utilityevaluator.converter.VariableConverter;
@@ -47,20 +48,15 @@ private static final JsonPointer NAME_PATH = JsonPointer.compile("/title");
  * in the app creation message. (Array of objects) */
 private static final JsonPointer PROVIDERS_PATH = JsonPointer.compile("/resources");
 
-    public Application (JsonNode appMessage) {
-        try {
-            //this.kubevela = appMessage.at(KUBEVELA_PATH);
-            this.kubevela= KubevelaAnalyzer.parseKubevela(appMessage.at(KUBEVELA_PATH).textValue());
-            this.applicationId = appMessage.at(UUID_PATH).textValue();
-            this.applicationName = appMessage.at(NAME_PATH).textValue();
-            JsonNode variables = appMessage.at(VARIABLES_PATH);
-            this.variables = VariableConverter.convertAndGroupVariables(variables);
-            this.costPerformanceIndicators = new HashMap<>();
-            log.info("Application message successfully parsed");
-
-        } catch (Exception e) {
-            log.error("Could not read app creation message", e);
-        }
+    public Application (JsonNode appMessage) throws JsonProcessingException {
+        //this.kubevela = appMessage.at(KUBEVELA_PATH);
+        this.kubevela= KubevelaAnalyzer.parseKubevela(appMessage.at(KUBEVELA_PATH).textValue());
+        this.applicationId = appMessage.at(UUID_PATH).textValue();
+        this.applicationName = appMessage.at(NAME_PATH).textValue();
+        JsonNode variables = appMessage.at(VARIABLES_PATH);
+        this.variables = VariableConverter.convertAndGroupVariables(variables);
+        this.costPerformanceIndicators = new HashMap<>();
+        log.info("Application message successfully parsed");
     }
 
     /*public Application(GenericDSLMessage message){


### PR DESCRIPTION
- Instead of producing uninitialized `Application` object, throw exception in the constructor.

- Catch error in the exn-connector message loop (a crash here will stop the listener)

Note that this pull request includes changes in the vendored KubevelaAnalyzer class; these changes will be included in upstream as well.